### PR TITLE
upgrade Slick to 1.4.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "package.json"
   ],
   "dependencies": {
-    "slick-carousel": "~1.3.7",
+    "slick-carousel": "~1.4.0",
     "angular": ">=1.2.0"
   },
   "homepage": "https://github.com/kbdaitch/angular-slick-carousel",

--- a/dist/slick.js
+++ b/dist/slick.js
@@ -71,12 +71,15 @@
             }
           });
           scope.init = function() {
-            var slick;
-            slick = element.slick(options);
+            var slickness;
+            slickness = element.slick(options);
             scope.internalControl = scope.control || {};
             SLICK_FUNCTION_WHITELIST.forEach(function(value) {
               scope.internalControl[value] = function() {
-                slick[value].apply(slick, arguments);
+                var args;
+                args = Array.prototype.slice.call(arguments);
+                args.unshift(value);
+                return slickness.slick.apply(element, args);
               };
             });
             scope.onDirectiveInit();

--- a/example/angular-slick-carousel/slick.js
+++ b/example/angular-slick-carousel/slick.js
@@ -71,12 +71,15 @@
             }
           });
           scope.init = function() {
-            var slick;
-            slick = element.slick(options);
+            var slickness;
+            slickness = element.slick(options);
             scope.internalControl = scope.control || {};
             SLICK_FUNCTION_WHITELIST.forEach(function(value) {
               scope.internalControl[value] = function() {
-                slick[value].apply(slick, arguments);
+                var args;
+                args = Array.prototype.slice.call(arguments);
+                args.unshift(value);
+                return slickness.slick.apply(element, args);
               };
             });
             scope.onDirectiveInit();

--- a/src/slick.coffee
+++ b/src/slick.coffee
@@ -96,23 +96,23 @@ module.directive 'slick', ['$timeout', '$templateCache', ($timeout, $templateCac
     angular.forEach attr, (value, key) ->
       options[key] = scope.$eval(value) if key in SLICK_OPTION_WHITELIST
 
-
     scope.init = ->
       # Call slick to initiate carousel
-      slick = element.slick(options)
+      slickness = element.slick(options)
 
       # Link slick functions with bi-directional control binding, if any
       scope.internalControl = scope.control || {}
       SLICK_FUNCTION_WHITELIST.forEach (value) ->
         # Delegate to underlying slick function with context set to element
         scope.internalControl[value] = ->
-          slick[value].apply(slick, arguments)
-          return
+          args = Array.prototype.slice.call(arguments)
+          args.unshift value
+          slickness.slick.apply(element, args)
         return
 
       scope.onDirectiveInit()
       return
 
     return
-  
+
   ]


### PR DESCRIPTION
the API in slick for calling methods on slick instances has changed, with the method name being passed as the first argument to $.fn.slick()

Maybe debatable if pre-populating these methods via SLICK_FUNCTION_WHITELIST is necessary given that you can call any internal slick method now this way, but made this work with minimal impact for now.