### PR TITLE
ISSUE - Slickness.not is not a function

### DIFF
--- a/dist/angular-slick.js
+++ b/dist/angular-slick.js
@@ -128,7 +128,7 @@ angular
           };
 
           destroy = function () {
-            var slickness = angular.element(element);
+            var slickness = $(element);
             if (slickness.hasClass('slick-initialized')) {
               slickness.remove('slick-list');
               slickness.slick('unslick');
@@ -140,7 +140,7 @@ angular
           init = function () {
             initOptions();
 
-            var slickness = angular.element(element);
+            var slickness = $(element);
 
             if (angular.element(element).hasClass('slick-initialized')) {
               if (options.enabled) {


### PR DESCRIPTION
Changed angular.element to jquery element as jqlite does not support .not()

Related Issue: https://github.com/devmark/angular-slick-carousel/issues/131